### PR TITLE
ラストスパート表示

### DIFF
--- a/isucon/portal/contest/templates/dashboard.html
+++ b/isucon/portal/contest/templates/dashboard.html
@@ -98,11 +98,11 @@
                 </p>
             </header>
             {% if is_last_spurt %}
-                <article class="message is-danger">
-                    <div class="message-body">
-                        <strong class="buruburu">残り1時間切ったのでみせられませぬぞ〜</strong>
-                    </div>
-                </article>
+            <article class="message is-danger">
+                <div class="message-body">
+                    <strong class="buruburu">残り1時間切ったのでみせられませぬぞ〜</strong>
+                </div>
+            </article>
             {% else %}
             <div class="card-table">
                 <div class="content">
@@ -135,9 +135,22 @@
             <footer class="card-footer">
                 <a href="{% url "scores" %}" class="card-footer-item">View All</a>
             </footer>
+            {% endif %}
         </div>
-        {% endif %}
     </section>
+
+    {% if is_last_spurt %}
+    <section>
+        <article class="message is-success">
+            <div class="message-header">
+                <span>Your score</span>
+            </div>
+            <div class="message-body">
+                <span>{{ team_score }}</span>
+            </div>
+        </article>
+    </section>
+    {% endif %}
 
     <section class="graph">
         <canvas id="myChart" width="400" height="200"></canvas>


### PR DESCRIPTION
ラストスパートのユーザ管理画面表示実装

* Redisから自分のスコアを取得
* ラストスパート判定処理 (現在時刻から１時間後のtimeをとり、settings.CONTEST_END_TIMEと比較)
* Dashboardにて、自身のスコア表示
* Dashboardにて、グラフに自分のスコア履歴のみ表示

fixes #41 