### PR TITLE
is-selected修正とscroll

### DIFF
--- a/isucon/portal/contest/templates/scores.html
+++ b/isucon/portal/contest/templates/scores.html
@@ -74,7 +74,7 @@
 {% endblock %}
 
 {% block script %}
-{% if not user.is_staff %}
+{% if not staff %}
 <script>
 window.onload = function() {
     let selected = document.getElementsByClassName('is-selected');


### PR DESCRIPTION
1. 全チームのスコア一覧ページにて、is-selected class属性を付与する条件分岐に用いているteam.idがおかしかったので、それを修正
2. ページロード後、is-selectedな行がちゃんと見えるようにスクロールするスクリプト設置

2について、必要かどうかも意見もらえると 🙇 